### PR TITLE
[37기 안나라] 상세페이지 장바구니 & 위시리스트 통신완료, 상세설명 컴포넌트 추가

### DIFF
--- a/src/pages/ProductDetail/ProductDetail.js
+++ b/src/pages/ProductDetail/ProductDetail.js
@@ -2,32 +2,21 @@ import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import PriceCalculator from './components/PriceCalculator';
 import ProductImg from './components/ProductImg';
-import SubNav from '../../components/SubNav/SubNav';
+import ProductDetailTab from '../ProductDetailTab/ProductDetailTab';
 import './ProductDetail.scss';
 
 const ProductDetail = () => {
   const params = useParams();
   const productId = params.itemId;
   const [product, setProduct] = useState({});
-  const {
-    name,
-    description,
-    price,
-    image_url,
-    option_price,
-    option_name,
-    max_amount,
-    main_category_name,
-    sub_category_name,
-  } = product;
+  const { name, description, price, image_url, option_price, option_name } =
+    product;
   const [optionPrice, setOptionPrice] = useState(0);
   const [optionId, setOptionId] = useState(null);
-
   useEffect(() => {
     fetch('/data/item.json')
       .then(response => response.json())
       .then(result => {
-        console.log(result.data[0]);
         setProduct(result.data[0]);
       });
   }, [productId]);
@@ -37,7 +26,7 @@ const ProductDetail = () => {
   const optionHandler = e => {
     if (e.target.value) {
       setOptionPrice(option_price);
-      setOptionId(e.target.value);
+      setOptionId(Number(e.target.value));
     } else {
       setOptionPrice(0);
       setOptionId(null);
@@ -47,10 +36,6 @@ const ProductDetail = () => {
   return (
     <div className="ProductDetail">
       <div className="product-wrap">
-        <SubNav
-          main_category_name={main_category_name}
-          sub_category_name={sub_category_name}
-        />
         <div className="product">
           <article className="product-item">
             {product.image_url && <ProductImg img={image_url} alt={name} />}
@@ -72,11 +57,16 @@ const ProductDetail = () => {
                 option_name={option_name}
                 optionHandler={optionHandler}
                 optionPrice={optionPrice}
-                max_amount={max_amount}
               />
             </div>
           </article>
         </div>
+        <ProductDetailTab
+          product={product}
+          // name={name}
+          // detail={detail}
+          // detail_image={detail_image}
+        />
       </div>
     </div>
   );

--- a/src/pages/ProductDetail/ProductDetail.js
+++ b/src/pages/ProductDetail/ProductDetail.js
@@ -8,13 +8,20 @@ const ProductDetail = () => {
   const params = useParams();
   const productId = params.itemId;
   const [product, setProduct] = useState({});
-  const { name, description, price, image_url, option_price, option_name } =
-    product;
+  const {
+    name,
+    description,
+    price,
+    image_url,
+    option_price,
+    option_name,
+    max_amount,
+  } = product;
   const [optionPrice, setOptionPrice] = useState(0);
   const [optionId, setOptionId] = useState(null);
 
   useEffect(() => {
-    fetch('/data/item.json')
+    fetch(`http://172.20.10.3:3000/items/${productId}`)
       .then(response => response.json())
       .then(result => {
         setProduct(result.data[0]);
@@ -57,6 +64,7 @@ const ProductDetail = () => {
                 option_name={option_name}
                 optionHandler={optionHandler}
                 optionPrice={optionPrice}
+                max_amount={max_amount}
               />
             </div>
           </article>

--- a/src/pages/ProductDetail/ProductDetail.js
+++ b/src/pages/ProductDetail/ProductDetail.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import PriceCalculator from './components/PriceCalculator';
 import ProductImg from './components/ProductImg';
+import SubNav from '../../components/SubNav/SubNav';
 import './ProductDetail.scss';
 
 const ProductDetail = () => {
@@ -16,14 +17,17 @@ const ProductDetail = () => {
     option_price,
     option_name,
     max_amount,
+    main_category_name,
+    sub_category_name,
   } = product;
   const [optionPrice, setOptionPrice] = useState(0);
   const [optionId, setOptionId] = useState(null);
 
   useEffect(() => {
-    fetch(`http://172.20.10.3:3000/items/${productId}`)
+    fetch('/data/item.json')
       .then(response => response.json())
       .then(result => {
+        console.log(result.data[0]);
         setProduct(result.data[0]);
       });
   }, [productId]);
@@ -33,7 +37,7 @@ const ProductDetail = () => {
   const optionHandler = e => {
     if (e.target.value) {
       setOptionPrice(option_price);
-      setOptionId(Number(e.target.value));
+      setOptionId(e.target.value);
     } else {
       setOptionPrice(0);
       setOptionId(null);
@@ -43,6 +47,10 @@ const ProductDetail = () => {
   return (
     <div className="ProductDetail">
       <div className="product-wrap">
+        <SubNav
+          main_category_name={main_category_name}
+          sub_category_name={sub_category_name}
+        />
         <div className="product">
           <article className="product-item">
             {product.image_url && <ProductImg img={image_url} alt={name} />}

--- a/src/pages/ProductDetail/components/PriceCalculator.js
+++ b/src/pages/ProductDetail/components/PriceCalculator.js
@@ -9,18 +9,11 @@ const PriceCalculator = ({
   optionHandler,
   optionPrice,
   price,
+  max_amount,
 }) => {
   const [quantity, setQuantity] = useState(1);
   const totalPrice = (price * 1 + optionPrice * 1) * quantity;
-  const [heartColor, setHeartColor] = useState('fa-regular fa-heart');
-
-  const minusQuantity = () => {
-    setQuantity(quantity > 1 ? quantity - 1 : 1);
-  };
-
-  const plusQuantity = () => {
-    setQuantity(quantity < 5 ? quantity + 1 : quantity);
-  };
+  const [wishList, setWishList] = useState(false);
 
   const addCartHandler = () => {
     fetch('http://172.20.10.6:3000/carts', {
@@ -44,7 +37,8 @@ const PriceCalculator = ({
 
   const addWishList = e => {
     e.preventDefault();
-    setHeartColor('fa-solid fa-heart');
+    setWishList(!wishList);
+    // setHeartColor('fa-solid fa-heart');
     fetch('http://172.20.10.3:3000/likes', {
       method: 'POST',
       headers: {
@@ -75,12 +69,20 @@ const PriceCalculator = ({
         <button
           className="quantity-button"
           name="minus"
-          onClick={minusQuantity}
+          onClick={() => {
+            setQuantity(quantity > 1 ? quantity - 1 : 1);
+          }}
         >
           <i className="fa-solid fa-minus" />
         </button>
         <input className="quantity-input" value={quantity} type="number" />
-        <button className="quantity-button" name="plus" onClick={plusQuantity}>
+        <button
+          className="quantity-button"
+          name="plus"
+          onClick={() => {
+            setQuantity(quantity < max_amount ? quantity + 1 : quantity);
+          }}
+        >
           <i className="fa-solid fa-plus" />
         </button>
       </div>
@@ -96,8 +98,14 @@ const PriceCalculator = ({
           value="장바구니"
           onClick={addCartHandler}
         />
-        <button onClick={addWishList} className="heart-button">
-          <i className={heartColor} />
+        <button
+          disabled={wishList}
+          onClick={addWishList}
+          className="heart-button"
+        >
+          <i
+            className={!wishList ? 'fa-regular fa-heart' : 'fa-solid fa-heart'}
+          />
         </button>
       </form>
     </div>

--- a/src/pages/ProductDetail/components/PriceCalculator.js
+++ b/src/pages/ProductDetail/components/PriceCalculator.js
@@ -68,7 +68,6 @@ const PriceCalculator = ({
       <div className="quantity">
         <button
           className="quantity-button"
-          name="minus"
           onClick={() => {
             setQuantity(quantity > 1 ? quantity - 1 : 1);
           }}
@@ -78,7 +77,6 @@ const PriceCalculator = ({
         <input className="quantity-input" value={quantity} type="number" />
         <button
           className="quantity-button"
-          name="plus"
           onClick={() => {
             setQuantity(quantity < max_amount ? quantity + 1 : quantity);
           }}

--- a/src/pages/ProductDetail/components/PriceCalculator.js
+++ b/src/pages/ProductDetail/components/PriceCalculator.js
@@ -16,7 +16,7 @@ const PriceCalculator = ({
   const [wishList, setWishList] = useState(false);
 
   const addCartHandler = () => {
-    fetch('http://172.20.10.6:3000/carts', {
+    fetch('http://172.20.10.5:3000/carts', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json;charset=utf-8',
@@ -34,7 +34,6 @@ const PriceCalculator = ({
       }
     });
   };
-
   const addWishList = e => {
     e.preventDefault();
     setWishList(!wishList);

--- a/src/pages/ProductDetail/components/ProductImg.scss
+++ b/src/pages/ProductDetail/components/ProductImg.scss
@@ -1,12 +1,11 @@
 @import '../../../styles/variable.scss';
 
 .product-img-container {
-  min-width: 500px;
+  width: 500px;
   height: 500px;
   overflow: hidden;
 
   .product-img {
-    width: 100%;
     height: 100%;
   }
 }
@@ -28,7 +27,6 @@
   }
 
   .product-sub-img {
-    width: 100%;
     height: 100%;
   }
 }

--- a/src/pages/ProductDetailTab/ProductDetailTab.js
+++ b/src/pages/ProductDetailTab/ProductDetailTab.js
@@ -5,11 +5,18 @@ import QaTab from './components/QaTab';
 import RefundTab from './components/RefundTab';
 import './ProductDetailTab.scss';
 
-const ProductDetailTab = () => {
+const ProductDetailTab = ({ product }) => {
   const [currentId, setCurrentId] = useState(1);
 
   const tabHandler = e => {
     setCurrentId(e);
+  };
+
+  const TAB_OBJ = {
+    1: <DetailTab product={product} />,
+    2: <ReviewTab />,
+    3: <QaTab />,
+    4: <RefundTab />,
   };
 
   return (
@@ -45,10 +52,3 @@ const TAB_TITLE = [
   { id: 3, name: 'Q&A' },
   { id: 4, name: '배송/환불' },
 ];
-
-const TAB_OBJ = {
-  1: <DetailTab />,
-  2: <ReviewTab />,
-  3: <QaTab />,
-  4: <RefundTab />,
-};

--- a/src/pages/ProductDetailTab/ProductDetailTab.scss
+++ b/src/pages/ProductDetailTab/ProductDetailTab.scss
@@ -3,8 +3,12 @@
 @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100;300;500;700&display=swap');
 
 .ProductDetailTab {
+  margin-top: 50px;
+
   .detail-menu-bar {
     @include flexSort(center, '');
+    padding-top: 50px;
+    border-top: 1px solid $grey-color;
 
     .tabs {
       @include flexSort(space-around, '');

--- a/src/pages/ProductDetailTab/components/DetailTab.js
+++ b/src/pages/ProductDetailTab/components/DetailTab.js
@@ -1,20 +1,19 @@
 import React from 'react';
 import './DetailTab.scss';
 
-const DetailTab = () => {
+const DetailTab = ({ product }) => {
   return (
     <section className="DetailTab">
       <div className="detail-main-wrap">
         <div className="detail-main-img-wrap">
-          <img className="detail-main-img" src="" alt="메인 상세 사진" />
-
+          <img
+            className="detail-main-img"
+            src={product.detail_image}
+            alt="메인 상세 사진"
+          />
           <div className="detail-main-contents">
-            <div className="detail-tag">tag</div>
-            <h1 className="detail-product-name">상품 이름</h1>
-            <p className="detail-product-txt">
-              간단한 <br />
-              상품설명
-            </p>
+            <h1 className="detail-product-name">{product.name}</h1>
+            <p className="detail-product-txt">{product.detail}</p>
           </div>
         </div>
       </div>

--- a/src/pages/ProductDetailTab/components/DetailTab.scss
+++ b/src/pages/ProductDetailTab/components/DetailTab.scss
@@ -4,16 +4,17 @@
   display: flex;
   justify-content: center;
   margin-top: 50px;
+  margin-bottom: 50px;
 
   .detail-main-wrap {
     .detail-main-img-wrap {
-      width: 1130px;
-      height: 850px;
+      width: 1000px;
+      height: 750px;
       background-color: $grey-color;
 
       .detail-main-img {
         position: absolute;
-        width: 100%;
+        width: 1000px;
       }
 
       .detail-main-slide {

--- a/src/pages/ProductDetailTab/components/QaTab.scss
+++ b/src/pages/ProductDetailTab/components/QaTab.scss
@@ -5,9 +5,8 @@
   margin-top: 50px;
 
   .qnA-wrap {
-    width: 1130px;
+    width: 950px;
     height: 55vw;
-    // background-color: $green-light-color;
 
     .review-title-wrap {
       @include flexSort(space-between, center);

--- a/src/pages/ProductDetailTab/components/RefundTab.scss
+++ b/src/pages/ProductDetailTab/components/RefundTab.scss
@@ -5,7 +5,7 @@
   margin-top: 50px;
 
   .refund-wrap {
-    width: 1130px;
+    width: 950px;
     height: 55vw;
 
     .refund-title {

--- a/src/pages/ProductDetailTab/components/ReviewTab.scss
+++ b/src/pages/ProductDetailTab/components/ReviewTab.scss
@@ -5,7 +5,7 @@
   margin-top: 50px;
 
   .review-wrap {
-    width: 1130px;
+    width: 950px;
     height: 55vw;
 
     .review-title-wrap {


### PR DESCRIPTION
## :: 최근 작업 주제

- [x]  기능 추가
- [ ]  리뷰 반영
- [ ]  리팩토링
- [ ]  버그 수정
- [ ]  컨벤션 수정

<br />

## :: 구현 목표

- 서버에서 가져온 데이터로 상품정보 화면 구현
- 상품옵션 및 수량 정보 장바구니에 담기
- 상품 위시리스트에 추가하기

<br />

## :: 구현 사항 설명

1. 상품정보 화면 구현(동적라우팅)
- useEffect 안에서 API호출을 진행합니다.
- useParams를 이용해 가져온 params의 id값인 `productId`를 useEffect의 의존성배열에 넣어줍니다.
- `productId`의 값이 변경될 때마다 새롭게 API호출을 합니다.
- 테스트 방법 : path parameter의 값이 바뀌면 컴포넌트가 리렌더링되는 것을 확인합니다.

2. 상품 장바구니에 담기
- 옵션 및 수량 선택 후 장바구니 버튼을 클릭하면 API호출을 진행합니다.
- fetch 함수의 body에 itemId, optionId, quantity를 담아서 요청합니다.
- 테스트 방법 : 장바구니 버튼을 클릭시 '장바구니에 상품이 담겼습니다!'라는 alert창이 실행되는 것을 확인합니다.

3. 상품 위시리스트 추가
- 하트버튼 클릭하면 버튼 색이 변경되고, API 호출을 진행합니다.
- fetch 함수의 body에 itemId를 담아서 요청합니다.
- 테스트 방법 : 하트 버튼을 클릭시 '위시리스트에 추가되었습니다!'라는 alert창이 실행되는 것을 확인합니다.


<br />

## :: 성장 포인트

- useEffect로 불러온 데이터(객체)가 undefined가 되면서 오류가 났을 때, 해결방법을 알게되었습니다.
    - 객체가 비어있지 않을 때 렌더링이 되도록 조건을 주었더니 오류가 해결되었습니다.
    
    ```jsx
    {product.image_url && (
                  <ProductImg img={image_url} alt={name} />
                )}
    ```
- 부모컴포넌트에서 자식컴포넌트로 값을 전달하는 것은 비교적 쉽지만, 자식컴포넌트에서 부모컴포넌트로 전달하는 것이 어려움
 -> state를 사용하는 최상위 컴포넌트에 선언하는 것이 좋다는 것을 알게되었습니다.



    <br />
    
    ## :: 기타 질문 및 특이 사항